### PR TITLE
Add code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://github.blog/2017-07-06-introducing-code-owners/
+operations/bylaws.rst           @pyvec/board
+operations/meeting-notes.rst    @pyvec/board


### PR DESCRIPTION
See [blog](https://github.blog/2017-07-06-introducing-code-owners/) for more info. I want to protect meeting notes and bylaws - modifying them should trigger a required review from at least one board member.