### PR TITLE
Add an extension which simplifies linking to Slack channels

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,9 +51,14 @@ Běžná práce
 #. Projekt zastavíte v terminálu pomocí :kbd:`Ctrl+C`
 
 Emoji
------
+^^^^^
 
 Při psaní můžete používat Emoji jako třeba |:cz:| nebo |:snake:|, ale nepište je přímo pomocí Unicode, ale za pomocí značek jako ``|:cz:|`` nebo ``|:snake:|``. Unicode znaky by se zobrazovaly na každém operačním systému jinak, ale tyto značky budou díky rozšíření `emojicodes <https://github.com/sphinx-contrib/emojicodes>`__ přeloženy na obrázky a ty se zobrazí vždy všem stejně. Mrkněte na `seznam podporovaných Emoji <https://sphinxemojicodes.readthedocs.io/>`__. Obrázky jsou z `Twemoji <https://twemoji.twitter.com/>`_.
+
+Slack
+^^^^^
+
+Při psaní lze psát ``:slack:`#pyladies``` nebo i jenom ``:slack:`pyladies```, což vytvoří odkaz na kanál :slack:`#pyladies` na Pyvec Slacku. Funguje to díky vlastnímu rozšíření Sphinxu, které lze najít v souboru ``_extensions/slack.py``.
 
 ReadTheDocs
 -----------

--- a/_extensions/slack.py
+++ b/_extensions/slack.py
@@ -1,0 +1,14 @@
+from docutils import nodes
+
+
+# https://docutils.readthedocs.io/en/sphinx-docs/howto/rst-roles.html
+def slack(name, rawtext, text, lineno, inliner,
+          options=None, content=None):
+    url = f"https://pyvec.slack.com/app_redirect?channel={text.lstrip('#')}"
+    node = nodes.reference(rawtext, text, refuri=url, **(options or {}))
+    return [node], []
+
+
+def setup(app):
+    app.add_role('slack', slack)
+    return {'version': '1.0', 'parallel_read_safe': True}

--- a/conf.py
+++ b/conf.py
@@ -1,11 +1,15 @@
 # Configuration file for the Sphinx documentation builder
 
 import os
+import sys
 
 
 # -- Environment -------------------------------------------------------------
 
 IS_READTHEDOCS = os.environ.get('READTHEDOCS') == 'True'
+
+# Explicitly put the extensions directory to Python path
+sys.path.append(os.path.abspath('_extensions'))
 
 
 # -- Project information -----------------------------------------------------
@@ -35,6 +39,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx_tabs.tabs',
     'sphinxemoji.sphinxemoji',
+    'slack',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/guides/promotion.rst
+++ b/guides/promotion.rst
@@ -42,9 +42,9 @@ Související: `Bus factor <https://en.wikipedia.org/wiki/Bus_factor>`__, `Padaw
 Slack
 ~~~~~
 
-Media tým má na `Pyvec Slacku <https://pyvec.slack.com/>`__ svou místnost, ``#pyconcz-media``, kde se radí a kam může kdokoliv přijít s méně urgentními věcmi. Tým má i svůj handle, ``@pyconcz-media-team``, jenž může kdokoliv z ostatních organizátorů použít, pokud chce vyvolat tým k akci a zadat mu práci.
+Media tým má na `Pyvec Slacku <https://pyvec.slack.com/>`__ svou místnost, :slack:`#pyconcz-media`, kde se radí a kam může kdokoliv přijít s méně urgentními věcmi. Tým má i svůj handle, ``@pyconcz-media-team``, jenž může kdokoliv z ostatních organizátorů použít, pokud chce vyvolat tým k akci a zadat mu práci.
 
-Existuje i tajný kanál ``#pyconcz-media-private``, který vznikl především proto, že si Media tým chtěl nasdílet nějaké e-mailové adresy privátní cestou.
+Existuje i tajný kanál :slack:`#pyconcz-media-private`, který vznikl především proto, že si Media tým chtěl nasdílet nějaké e-mailové adresy privátní cestou.
 
 
 Organizace práce
@@ -57,7 +57,7 @@ Vedoucí
    Člen týmu si může vzít na starost i úkol, který neví jak zpracovat - to je v pořádku. Vedoucí všechno vysvětlí, naučí, a zapíše sem.
 
 Přístupy
-   Členové týmu by měli být na `Pyvec Slacku <https://pyvec.slack.com/>`__ v místnosti ``#pyconcz-media`` a v týmu ``@pyconcz-media-team``, ve Facebookové skupine `Pyonýři <https://www.facebook.com/groups/pyonieri/>`__, měli by být nastavení jako spoluorganizátoři Facebookové události pro konferenci (příspěvky od organizátorů se zobrazují viditelněji), měli by mít přístup do Twitter účtu `@pyconcz <https://twitter.com/pyconcz>`__ přes `TweetDeck Teams <https://blog.twitter.com/official/en_us/a/2015/introducing-tweetdeck-teams.html>`__, a měli by umět posílat e-maily do skupiny `django-cs <https://groups.google.com/forum/#!forum/django-cs>`__ a `konference py.cz <https://www.py.cz/mailman/listinfo/python>`__.
+   Členové týmu by měli být na `Pyvec Slacku <https://pyvec.slack.com/>`__ v místnosti :slack:`#pyconcz-media` a v týmu ``@pyconcz-media-team``, ve Facebookové skupine `Pyonýři <https://www.facebook.com/groups/pyonieri/>`__, měli by být nastavení jako spoluorganizátoři Facebookové události pro konferenci (příspěvky od organizátorů se zobrazují viditelněji), měli by mít přístup do Twitter účtu `@pyconcz <https://twitter.com/pyconcz>`__ přes `TweetDeck Teams <https://blog.twitter.com/official/en_us/a/2015/introducing-tweetdeck-teams.html>`__, a měli by umět posílat e-maily do skupiny `django-cs <https://groups.google.com/forum/#!forum/django-cs>`__ a `konference py.cz <https://www.py.cz/mailman/listinfo/python>`__.
 
 Úkoly od spoluorganizátorů
    Pokud na Slacku přijde úkol ("zpropagujte datum konference") a v Media týmu je víc lidí, je dobré na Slack napsat "jdu na to", pokud to jdu udělat, aby ostatní z týmu věděli, že už to nemusí řešit. Případně "budu na to mít čas dnes večer" (třeba to někdo zvládne i dřív) nebo "udělám Facebook" (někdo jiný si vezme Twitter).

--- a/operations/bylaws.rst
+++ b/operations/bylaws.rst
@@ -102,12 +102,12 @@ b)  volit členy :ref:`výboru <vybor>` spolku a být zvolen za člena výboru s
 c)  být informován o činnosti spolku,
 
     .. note::
-        Především skrze :ref:`Slack <slack>`, kanál `#pyvec <https://app.slack.com/client/T12KEU0G4/C12MP1GDB>`__.
+        Především skrze :ref:`Slack <slack>`, kanál :slack:`#pyvec`.
 
 d)  předkládat návrhy, připomínky a náměty k činnosti spolku,
 
     .. note::
-        Především skrze :ref:`Slack <slack>`, kanál `#pyvec <https://app.slack.com/client/T12KEU0G4/C12MP1GDB>`__, nebo e-mailem na adresu spolku: info@pyvec.org.
+        Především skrze :ref:`Slack <slack>`, kanál :slack:`#pyvec`, nebo e-mailem na adresu spolku: info@pyvec.org.
 
 e)  zastupovat spolek v záležitostech, ke kterým byl výborem pověřen a nakládat s majetkovými hodnotami v rozsahu tohoto pověření.
 
@@ -243,7 +243,7 @@ Návrh musí obsahovat alespoň návrh usnesení, podklady potřebné pro jeho p
 Výbor oznámí členům spolku písemně nebo jiným vhodným způsobem výsledek hlasování, a pokud bylo usnesení přijato, oznámí jim i celý obsah přijatého usnesení. Neučiní-li to bez zbytečného odkladu, může oznámení učinit na náklady spolku ten, kdo usnesení navrhl.
 
 .. note::
-    V praxi mají členové pro komunikaci k dispozici i :ref:`Slack <slack>` s “tajným” kanálem `#pyvec-members <https://app.slack.com/client/T12KEU0G4/GL0H589SQ>`__.
+    V praxi mají členové pro komunikaci k dispozici i :ref:`Slack <slack>` s “tajným” kanálem :slack:`#pyvec-members`.
 
 .. _vybor:
 
@@ -298,7 +298,7 @@ Výbor může jednat a přijímat svá rozhodnutí také mimo zasedání, a to k
 Veškerá korespondence mezi členy výboru, která bude odeslána z e-mailové adresy člena výboru, uvedené v seznamu členů, se považuje za korespondenci tohoto člena výboru.
 
 .. note::
-    Poslední věta je tu proto, abychom se vyhnuli ověřeným elektronickým podpisům apod. V praxi výbor komunikuje přes interní e-mail board@pyvec.org a skrze :ref:`Slack <slack>`, “tajný” kanál `#pyvec-board <https://app.slack.com/client/T12KEU0G4/G32A3QKAR>`__.
+    Poslední věta je tu proto, abychom se vyhnuli ověřeným elektronickým podpisům apod. V praxi výbor komunikuje přes interní e-mail board@pyvec.org a skrze :ref:`Slack <slack>`, “tajný” kanál :slack:`#pyvec-board`.
 
 X. Seznam členů
 ^^^^^^^^^^^^^^^

--- a/operations/domains.rst
+++ b/operations/domains.rst
@@ -51,4 +51,4 @@ Přístup do účtu Pyvce na `domena.cz <https://domena.cz>`__ mají:
 - Petr Viktorin
 - Vítek Pliska
 
-Potřebujete-li řešit něco s doménami, pište na info@pyvec.org nebo do kanálu `#domeny <https://pyvec.slack.com/messages/C6ZMKC50E/>`__ na :ref:`Slacku <slack>`.
+Potřebujete-li řešit něco s doménami, pište na info@pyvec.org nebo do kanálu :slack:`#domeny` na :ref:`Slacku <slack>`.

--- a/operations/meeting-notes.rst
+++ b/operations/meeting-notes.rst
@@ -51,7 +51,7 @@ např pro PyCon CZ. Poznámky
 [které byly v době zveřejnění zápisu :ref:`již zpracovány <financni-podpora>`]:
 
     * pycon vs pyladies vs pyvo-brno obálky.
-    * ted muze na slacku do #money, vic info neni.
+    * ted muze na slacku do :slack:`#money`, vic info neni.
     * honza predstavil mini grantiky, alesovi dava smysl.
     * formular na venek? jak velke jsou obalky? martin to vi.
     * pyvec je legalni entita. pycon neni obalka.

--- a/operations/runbooks.rst
+++ b/operations/runbooks.rst
@@ -56,7 +56,7 @@ Jak se stát členem
       Zásluh nemusí být moc, ani nemusí být žádného těžkého kalibru. Nejedná se o členství za zásluhy ani o poměřování, jde spíše o **představení se**, aby výbor věděl, s kým má tu čest. Komunita je celorepubliková a pro členy výboru nemusí být jednoduché mít přehled o všech aktivních lidech ve všech regionech.
 
 #. Výbor by ti měl potvrdit přijetí přihlášky. Výbor bude následně o tvé přihlášce hlasovat. Záleží na vytíženosti členů výboru, ale nemělo by to nejspíš trvat déle než týden nebo dva.
-#. Výbor odpoví a obeznámí tě s výsledkem hlasování. Měl by uveřejnit zápis do :ref:`zapisy` a přidat tě na Slacku do kanálu `#pyvec-members <https://pyvec.slack.com/messages/GL0H589SQ/>`__.
+#. Výbor odpoví a obeznámí tě s výsledkem hlasování. Měl by uveřejnit zápis do :ref:`zapisy` a přidat tě na Slacku do kanálu :slack:`#pyvec-members`.
 #. Jakmile je zápis z hlasování zveřejněn, můžeš jej spolu s e-maily použít jako důkaz o svém přijetí za člena a doklad svého existujícího členství.
 #. Pyvec nemá zaveden členský poplatek, takže od této chvíle se stačí řídit :ref:`stanovami <stanovy>`.
 
@@ -116,14 +116,14 @@ Přijetí nového člena
 +------------------------------+-----------------+
 
 #. Osoba žádající o členství napíše e-mail na info@pyvec.org. Tím vznikne doklad o jeho žádosti (ten e-mail, který je možné v případě potřeby dohledat).
-#. V kanále `#pyvec-board <https://pyvec.slack.com/messages/G32A3QKAR/>`__ někdo nadnese:
+#. V kanále :slack:`#pyvec-board` někdo nadnese:
 
    .. code-block:: text
 
       @board hlasujeme o přijetí XYZ za člena Pyvce, dejte :+1: pokud souhlasíte
 
 #. Čeká se, dokud členové výboru odhlasují tak, že jsou :ref:`usnášeníschopní <usnasenischopnost-vyboru>`, tzn. musí odhlasovat minimálně předseda a další dva členové výboru.
-#. Po hlasování někdo z výboru odpoví na e-mail (opět pro dohledatelnost) jak to dopadlo a pokud byla osoba přijata, zapíše ji do `tabulky <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__ a přidá do kanálu `#pyvec-members <https://pyvec.slack.com/messages/GL0H589SQ/>`__.
+#. Po hlasování někdo z výboru odpoví na e-mail (opět pro dohledatelnost) jak to dopadlo a pokud byla osoba přijata, zapíše ji do `tabulky <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__ a přidá do kanálu :slack:`#pyvec-members`.
 #. Hlasování musí být zdokumentováno jako :ref:`zapis-e-hlasovani`.
 #. Jakmile je zápis z hlasování zveřejněn, nový člen jej může spolu s e-maily použít jako důkaz o svém přijetí za člena a doklad svého existujícího členství.
 

--- a/operations/support-money.rst
+++ b/operations/support-money.rst
@@ -55,7 +55,7 @@ Granty
 
 Pokud na svou věc nemáte sponzora, můžete požádat Pyvec o grant. Pyvec disponuje penězi, které na jeho účtě zbyly z nevyčerpaných sponzorských darů, z neurčených darů a z přebytků hospodaření konference `PyCon CZ <https://cz.pycon.org/>`__. Slovo grant může někoho děsit, ale v našem podání to není nic byrokratického. Grant můžete žádat na libovolnou záležitost, která souvisí s misí Pyvce (viz stanovy: :ref:`ucel-spolku` a :ref:`formy-cinnosti-spolku`), ať už jde o stokoruny nebo desetitisíce: nájmy, trička, samolepky, projektor...
 
-#. Na e-mail info@pyvec.org nebo do kanálu `#money <https://pyvec.slack.com/messages/C9E81JFS5/>`__ na :ref:`Slacku <slack>` napište žádost o peníze. Pokud píšete na Slacku, přidejte mention na ``@board``, ať si toho všimnou členové :term:`výboru <Výbor>`. Snažte se v žádosti zodpovědět následující:
+#. Na e-mail info@pyvec.org nebo do kanálu :slack:`#money` na :ref:`Slacku <slack>` napište žádost o peníze. Pokud píšete na Slacku, přidejte mention na ``@board``, ať si toho všimnou členové :term:`výboru <Výbor>`. Snažte se v žádosti zodpovědět následující:
 
    - Kdo jste?
    - Kolik potřebujete? (i kdyby to měl být jen odhad nebo rozmezí)
@@ -83,7 +83,7 @@ Pokud na svou věc nemáte sponzora, můžete požádat Pyvec o grant. Pyvec dis
 
 Příklad:
 
-   Zuzka by chtěla natisknout třička pro `PyLadies <https://pyladies.cz/>`__. Na tričkách nechce loga sponzorů, takže sponzory nehledá, požádá Pyvec o grant. Do `#money <https://pyvec.slack.com/messages/C9E81JFS5/>`__ napíše:
+   Zuzka by chtěla natisknout třička pro `PyLadies <https://pyladies.cz/>`__. Na tričkách nechce loga sponzorů, takže sponzory nehledá, požádá Pyvec o grant. Do :slack:`#money` napíše:
 
    *@board Ahoj, jsem organizátorka PyLadies v Zeleném Údolí. Rádi bychom natiskli PyLadies trička. Podle toho, jaký bude zájem, budeme potřebovat 10 až 30 000 Kč. Trička jsou jedinou odměnou dobrovolníkům, posilují soudržnost mezi organizátory i absolventkami kurzů a zároveň šíří povědomí o PyLadies, když v nich lidi chodí po světě. Jde o trička pro všechna města, jsme domluvené s organizátorkami z Modrého Města i Žlutého Vrchu.*
 
@@ -101,7 +101,7 @@ Granty mohou být :ref:`jednorázové <granty>` nebo paušální. Ty paušální
 
 Postup získání grantu je :ref:`stejný jako u jednorázových <granty>`, jen s tím rozdílem, že nežádáte o jednorázové peníze, ale o pravidelnou částku na měsíc. Opět platí, že Pyvec může věci :ref:`proplácet <jak-proplatit>` jen oproti účetnímu dokladu, tzn. účtence nebo faktuře. Grant 200 Kč/měsíc, je tedy míněn "proplatíme účetní doklady do výše 200 Kč měsíčně". Po získání paušálního grantu **nemusíte psát článek na blog**. (Ale můžete!) Příklad:
 
-   Lumír do `#money <https://pyvec.slack.com/messages/C9E81JFS5/>`__ napíše:
+   Lumír do :slack:`#money` napíše:
 
    *@board Zdar jak sviňa, v Zeleném Údolí děláme kurzy pro začátečníky, dva semestry ročně. Máme u toho malé výdaje, v podstatě kancelářské potřeby. Kurzy prošlo za poslední rok 40 lidí ročně a mají dlouhodobě skvělé ohlasy od účastníků. Pomohlo by nám proplatit 100 Kč měsíčně.*
 

--- a/operations/support.rst
+++ b/operations/support.rst
@@ -5,7 +5,7 @@ Podpora komunitních aktivit
 
 Pyvec nikomu neříká, co má dělat. Pomáhá těm, kteří se o něco snaží — je to servisní organizace. Má pod palcem `síť kontaktů <http://pyvec.slack.com/>`__, :ref:`finanční zdroje <financni-podpora>`, know-how, atd., kterými podporuje dobrovolníky s nápady a odhodláním. Pyvec primárně podporuje projekty, které jsou `otevřené <https://cs.wikipedia.org/wiki/Otev%C5%99en%C3%BD_software>`__ a `inkluzivní <https://cs.wikipedia.org/wiki/Inkluze_(sociologie)>`__.
 
-Dotazy pište na info@pyvec.org nebo do kanálu `#pyvec <https://pyvec.slack.com/messages/C12MP1GDB/>`__ na :ref:`Slacku <slack>`.
+Dotazy pište na info@pyvec.org nebo do kanálu :slack:`#pyvec` na :ref:`Slacku <slack>`.
 
 .. contents:: Oblasti podpory
    :depth: 1
@@ -20,7 +20,7 @@ Síť kontaktů
 
 Pyvec provozuje diskusi `pyvec.slack.com <https://pyvec.slack.com/>`__ určenou primárně pro organizátory komunitních akcí, lektory programování v jazyce Python, a jiné aktivní dobrovolníky.
 
-Pro přístup pište na info@pyvec.org, ideálně s popisem toho, co pro Python v ČR děláte nebo dělat chcete. Jakmile se dostanete dovnitř, představte se ostatním v kanálu `#introductions <https://pyvec.slack.com/messages/C4Q1K2724/>`__.
+Pro přístup pište na info@pyvec.org, ideálně s popisem toho, co pro Python v ČR děláte nebo dělat chcete. Jakmile se dostanete dovnitř, představte se ostatním v kanálu :slack:`#introductions`.
 
 
 Finanční podpora
@@ -28,7 +28,7 @@ Finanční podpora
 
 Přes Pyvec tečou peníze české Python komunity, ať už jde o otočení sponzorských peněz nebo o přispívání na komunitní projekty pomocí :ref:`grantů <granty>`. Všechno najdete detailně sepsané na samostatné stránce :ref:`financni-podpora`.
 
-Pište na info@pyvec.org nebo diskutujte v kanálu `#money <https://pyvec.slack.com/messages/C9E81JFS5/>`__ na :ref:`Slacku <slack>`.
+Pište na info@pyvec.org nebo diskutujte v kanálu :slack:`#money` na :ref:`Slacku <slack>`.
 
 
 Návody
@@ -44,7 +44,7 @@ Domény
 
 Máme účet na `domena.cz <https://www.domena.cz/>`__, kde pro českou Python komunitu spravujeme a platíme domény jako pyvec.org, pyvo.cz, nebo pyladies.cz. Celý přehled je na stránce :ref:`domeny`. Pokud zvažujete rozjetí komunitního projektu pod novou doménou, apelujeme na vás, abyste nás kontaktovali a nechali Pyvec doménu registrovat. Pozdější převody domén na Pyvec jsou komplikované a zdlouhavé.
 
-Pište na info@pyvec.org nebo v kanálu `#domeny <https://pyvec.slack.com/messages/C6ZMKC50E/>`__ na :ref:`Slacku <slack>`.
+Pište na info@pyvec.org nebo v kanálu :slack:`#domeny` na :ref:`Slacku <slack>`.
 
 
 .. _gsuite:
@@ -54,7 +54,7 @@ GSuite
 
 Jako neziskovka máme k dispozici velmi výhodný tarif pro `G Suite <https://gsuite.google.com/>`__, tedy sadu aplikací od Google na vlastní doméně. Z těch je užitečná především emailová schránka. Umíme nastavit, aby fungovaly adresy jako info@pyladies.cz nebo praha@pyladies.cz.
 
-Pište co potřebujete na info@pyvec.org nebo v kanálu `#gsuite <https://pyvec.slack.com/messages/C9FE1BKKL/>`__ na :ref:`Slacku <slack>`.
+Pište co potřebujete na info@pyvec.org nebo v kanálu :slack:`#gsuite` na :ref:`Slacku <slack>`.
 
 
 Google Drive
@@ -62,7 +62,7 @@ Google Drive
 
 Máme sdílený Google Drive, kde se to hemží všemi možnými dokumenty potřebnými pro chystání a provoz komunitních akcí a projektů.
 
-Pro přístup pište na info@pyvec.org nebo v kanálu `#gsuite <https://pyvec.slack.com/messages/C9FE1BKKL/>`__ na :ref:`Slacku <slack>`.
+Pro přístup pište na info@pyvec.org nebo v kanálu :slack:`#gsuite` na :ref:`Slacku <slack>`.
 
 
 Poradenství ohledně GDPR
@@ -70,7 +70,7 @@ Poradenství ohledně GDPR
 
 `GDPR <https://cs.wikipedia.org/wiki/Obecn%C3%A9_na%C5%99%C3%ADzen%C3%AD_o_ochran%C4%9B_osobn%C3%ADch_%C3%BAdaj%C5%AF>`__ už jsme museli řešit pro několik webů a akcí, takže jsme schopni vám poskytnout základní poradenství. Kdyby bylo potřeba, zajistíme i právní servis.
 
-Pište co potřebujete na info@pyvec.org nebo v kanálu `#gdpr <https://pyvec.slack.com/messages/CA1JN88HH/>`__ na :ref:`Slacku <slack>`.
+Pište co potřebujete na info@pyvec.org nebo v kanálu :slack:`#gdpr` na :ref:`Slacku <slack>`.
 
 
 Poradenství ohledně inkluzivity akcí
@@ -78,4 +78,4 @@ Poradenství ohledně inkluzivity akcí
 
 Pyvec se snaží, aby jím podporované akce byly inkluzivní a přístupné pro co největší škálu lidí. Jestliže v tomto tématu tápete, rádi vám vysvětlíme základy problematiky a poskytneme rady na konkrétní kroky, které můžete udělat, aby vaše akce byla přístupnější.
 
-Pište na info@pyvec.org nebo v kanálu `#coc <https://pyvec.slack.com/messages/CC2UMSC0M/>`__ na :ref:`Slacku <slack>`.
+Pište na info@pyvec.org nebo v kanálu :slack:`#coc` na :ref:`Slacku <slack>`.


### PR DESCRIPTION
Based on information from https://api.slack.com/reference/deep-linking