### PR TITLE
Přidej návod jak pracuje kalendář

### DIFF
--- a/guides/calendar.rst
+++ b/guides/calendar.rst
@@ -24,6 +24,6 @@ Jednorázové akce lze přidat přes Google kalendář `Czech Python Events <htt
 Jak to funguje
 --------------
 
-Sestavení kalendáře se spouští automaticky jednou denně jako `akce GitHubu <https://github.com/pyvec/python.cz/actions>`__. Spouětí se též při každém začlenění změn.
+Sestavení kalendáře se spouští automaticky jednou denně jako `akce GitHubu <https://github.com/pyvec/python.cz/actions>`__. Spouští se též při každém začlenění změn.
 
-Akce z nově přidaného kalendáře se tedy stáhnou okamžitě, v příapdě těch přidanýcj do stávajících kalendářů to může trvat do druhého dne. Chcete-li to uspíšit, řekněte někomu z organizátorů, nebo napište na `info@pyvec.org <mailto:info@pyvec.org>`__, ať sestavení (akci GitHubu) spustí ručně.
+Akce z nově přidaného kalendáře se tedy stáhnou okamžitě, v případě těch přidaných do stávajících kalendářů to může trvat do druhého dne. Chcete-li to uspíšit, řekněte někomu z organizátorů, nebo napište na `info@pyvec.org <mailto:info@pyvec.org>`__, ať sestavení (akci GitHubu) spustí ručně.

--- a/guides/calendar.rst
+++ b/guides/calendar.rst
@@ -1,0 +1,29 @@
+Jak funguje kalendář akcí
+=========================
+
+Na webu Python.cz se nachází `kalendář <https://python.cz/akce/>`__ nadcházejících srazů, konferencí
+a dalších akcí české pythonní komunity. Tyto akce se oznamují též na `Slacku <https://pyvec.slack.com/>`__ v kanálech `#calendar <https://pyvec.slack.com/#calendar>`__ (při každé změně) a `#announcements <https://pyvec.slack.com/#announcements>`__ (týdenní souhrn).
+
+Celý kalendář se sestavuje každý den dynamicky z různých zdrojů. Lze si jej též `stáhnout <https://python.cz/events.ics>`__ ve formátu `iCal <https://cs.wikipedia.org/wiki/ICalendar>`__.
+
+Jak přispívat
+-------------
+
+Pravidelné akce
+~~~~~~~~~~~~~~~
+
+Pravidelné akce lze přidat přes tzv. iCal export. Ten může generovat přímo vaše webová stránka (jako v případě `pyvo.cz <https://pyvo.cz/>`__), nebo jej lze vytáhnout z nějaké služby (Google Calendar, meetup.com).
+
+URL exportu pak na náš web přidejte do souboru `static/data/events_feeds.yml <https://github.com/pyvec/python.cz/edit/master/pythoncz/static/data/events_feeds.yml>`__ repozitáře `pyvec/python.cz <https://github.com/pyvec/python.cz>`__ pomocí pull requestu. Po začlenění se akce objeví rovnou a následně se budou načítat samy každý den.
+
+Jednorázové akce
+~~~~~~~~~~~~~~~~
+
+Jednorázové akce lze přidat přes Google kalendář `Czech Python Events <https://calendar.google.com/calendar/embed?src=kfdeelic1a13jsp7jvai861vfs%40group.calendar.google.com&ctz=Europe%2FPrague>`__. Do kalendáře má přístup mnoho z organizátorů existujících Python akcí. Poproste je, ať vaši akci přidají, nebo napište na `info@pyvec.org <mailto:info@pyvec.org>`__. První URL z popisu události se zobrazí jako odkaz.
+
+Jak to funguje
+--------------
+
+Sestavení kalendáře se spouští automaticky jednou denně jako `akce GitHubu <https://github.com/pyvec/python.cz/actions>`__. Spouětí se též při každém začlenění změn.
+
+Akce z nově přidaného kalendáře se tedy stáhnou okamžitě, v příapdě těch přidanýcj do stávajících kalendářů to může trvat do druhého dne. Chcete-li to uspíšit, řekněte někomu z organizátorů, nebo napište na `info@pyvec.org <mailto:info@pyvec.org>`__, ať sestavení (akci GitHubu) spustí ručně.

--- a/guides/calendar.rst
+++ b/guides/calendar.rst
@@ -2,7 +2,7 @@ Jak funguje kalendář akcí
 =========================
 
 Na webu Python.cz se nachází `kalendář <https://python.cz/akce/>`__ nadcházejících srazů, konferencí
-a dalších akcí české pythonní komunity. Tyto akce se oznamují též na `Slacku <https://pyvec.slack.com/>`__ v kanálech `#calendar <https://pyvec.slack.com/#calendar>`__ (při každé změně) a `#announcements <https://pyvec.slack.com/#announcements>`__ (týdenní souhrn).
+a dalších akcí české pythonní komunity. Tyto akce se oznamují též na `Slacku <https://pyvec.slack.com/>`__ v kanálech :slack:`#calendar` (při každé změně) a :slack:`#announcements` (týdenní souhrn).
 
 Celý kalendář se sestavuje každý den dynamicky z různých zdrojů. Lze si jej též `stáhnout <https://python.cz/events.ics>`__ ve formátu `iCal <https://cs.wikipedia.org/wiki/ICalendar>`__.
 

--- a/index.rst
+++ b/index.rst
@@ -18,6 +18,7 @@ Obsah
    guides/django-girls
    guides/high-school-class
    guides/promotion
+   guides/calendar
    guides/slido-moderation
 
    operations/index


### PR DESCRIPTION
Založena nová sekce popisující, co je kalendář akcí na Python.cz a jak do něj přispívat. Uvedené jsou jak konkrétní kroky pro přidání pravidelných i jednorázových akcí, tak i stručný popis funkčnosti na pozadí.