### PR TITLE
Přidání Anežky do lidí s přístupem na Twitter Pyva

### DIFF
--- a/operations/twitter.rst
+++ b/operations/twitter.rst
@@ -33,7 +33,7 @@ Admin
    :twitter:`honzajavorek`, :twitter:`lumirbalhar`, :twitter:`hroncok`, :twitter:`EnCuKou`, :twitter:`kvbik`
 
 Contributor
-   :twitter:`janbednarik`, :twitter:`JirkaV`, :twitter:`MartinCurlej`, :twitter:`_apophys_`, :twitter:`krcmar`, :twitter:`tbedrich`, :twitter:`aleszoulek`, :twitter:`lurkingideas`, :twitter:`JiriPsotka`, :twitter:`stibi`
+   :twitter:`janbednarik`, :twitter:`JirkaV`, :twitter:`MartinCurlej`, :twitter:`_apophys_`, :twitter:`krcmar`, :twitter:`tbedrich`, :twitter:`aleszoulek`, :twitter:`lurkingideas`, :twitter:`JiriPsotka`, :twitter:`stibi`, :twitter:`anezkamll`
 
 @pyconcz
 ^^^^^^^^


### PR DESCRIPTION
Anežka bude tweetovat za brněnské Pyvo.