### PR TITLE
Edits to elections

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -6,17 +6,6 @@
 }
 
 /*
-  Fixing strange behavior of the RTD theme
-*/
-.rst-content ul {
-  margin-bottom: 12px !important;
-}
-
-.rst-content ul:last-child {
-  margin-bottom: 0 !important;
-}
-
-/*
   Fixing margin of illustrations
 */
 .rst-content .image-reference img {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "pyvec_docs.ext.slack",
     "pyvec_docs.ext.twitter",
     "pyvec_docs.ext.gh_repo",
+    "pyvec_docs.ext.board_dates",
     "myst_parser",
 ]
 

--- a/docs/operations/elections.rst
+++ b/docs/operations/elections.rst
@@ -1,43 +1,48 @@
 Volby do výboru
 ===============
 
-Funkční období :term:`výboru <Výbor>` je dle :ref:`stanov <stanovy>` tři roky, členové spolku ze svých řad volí pět členů. To se děje na členské schůzi, kterou výbor k této příležitosti svolává.
+Funkční období :term:`výboru <Výbor>` je dle :ref:`stanov <stanovy>` tři roky, členové spolku ze svých řad volí pět členů. Nově zvolený výbor si potom sám volí, kdo z těchto pěti bude předseda a případně kdo bude pokladník (když se nerozhodne volit pokladníka, je jím automaticky předseda).
 
-Nově zvolený výbor si potom sám volí, kdo z těchto pěti bude předseda a případně kdo bude pokladník (když se nerozhodne volit pokladníka, je jím automaticky předseda).
-
-.. note::
-    Přečíst ještě `PEP 8102 <https://peps.python.org/pep-8102/>`__ a případně se inspirovat? Dořešit.
+Volby do výboru probíhají asynchronně a zpravidla trvají týden, aby stihli všichni zahlasovat.
 
 Kdy se volí
 -----------
 
-- Předchozí volba: **8.4.2019**
-- Příští volba: **21.3.2022**
++------------------------------------+--------------------+
+| |:ballot_box:| Předchozí volba     | |board_start|      |
++------------------------------------+--------------------+
+| |:warning:| Příští volba           | |board_end|        |
++------------------------------------+--------------------+
 
 Příprava
 --------
 
-- Postupuje se podle stanov, svoláváme :ref:`členskou schůzi <clenska-schuze>`.
-- Výbor na nějaké schůzi s předstihem určí přesné datum členské schůze.
-- Někdo z výboru vezme e-mailové adresy členů ze `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__ a pošle jim pozvánku na členskou schůzi. Pozvánka musí obsahovat místo, čas a program jednání členské schůze. Kromě toho by měl výbor schůzi oznámit i v kanálu :slack:`#pyvec-members`. (Pro inspiraci, pozvánka na členskou schůzi `EuroPython Society <https://www.europython-society.org/europython-society-general-assembly-2020/>`__.)
-- Výbor dá členům vědět, jak lze podávat nominace, jak kandidovat. Kandidovat do výboru může jakýkoliv člen Pyvce.
-- Ideálně se pokusí členy motivovat k tomu, aby kandidovali, a to komunikací s členy, ukazováním toho, jak výbor pracuje, jak vypadá běžná schůze výboru (např. zveřejněním video nahrávky), apod. Výbor může také neformálně oslovovat vhodné kandidáty a přesvědčovat je, že mají kandidovat.
-- Členové mohou někoho nominovat a tím jej motivovat ke kandidatuře, ale s kandidaturou musí nakonec dotyčný souhlasit, aby byla platná.
-- Přihlášky se oznamují v kanálu :slack:`#pyvec-members`. (Pro inspiraci, `kandidatury do EuroPython Society <https://www.europython-society.org/list-of-eps-board-candidates-for-20192020/>`__.) Seznam kandidátů by bylo dobré zapisovat třeba sem do této stránky, ať je někde přehledný seznam. Pozor na GDPR, kontrolovat v `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__, zda daná osoba může být někde veřejně takto prezentovaná.
-- Neomezujeme kandidáty na ty přihlášené předem. Kandidáti se mohou navrhnout nebo nominovat jiné kandidáty klidně až v průběhu hlasování. Je ale pro hlasující lepší, když se mohou s kandidáty seznámit předem.
+- Volební týden startuje na členské schůzi, kterou výbor k této příležitosti svolává. Většinou se to dělá tak, že se k té jedné členské schůzi ročně, která se svolává ke schválení účetní závěrky, akorát přidá odstartování voleb.
+- Výbor na nějaké svojí schůzi s předstihem určí přesné datum :ref:`členské schůze <clenska-schuze>`. Datum se vybírá despoticky podle možností výboru a asi by se mělo vyhnout např. státním svátkům apod, kdy lidi mívají dovolené.
+- Někdo z výboru vezme e-mailové adresy členů ze `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__ a pošle všem pozvánku na členskou schůzi, nejméně 10 dnů předem. Pozvánka musí obsahovat místo, čas a program jednání členské schůze. Měla by zmínit, že budou volby, a jak fungují nominace a kandidatury (viz níže).
+- Kromě toho by měl výbor schůzi oznámit i v kanálu :slack:`#pyvec-members`. Pro inspiraci, `pozvánka na členskou schůzi EuroPython Society <https://www.europython-society.org/europython-society-general-assembly-2020/>`__.
 
-.. note::
-    Dořešit, zda se opravdu mohou kandidáti přidávat nebo ubírat v průběhu voleb. Závisí na zvoleném technickém řešení, zda umožňuje měnit hlas v průběhu týdne.
+Nominace a kandidatury
+----------------------
+
+- Kandidovat do výboru může jakýkoliv člen Pyvce. Nominace, kandidatury a další detaily ohledně voleb se tradičně oznamují v kanálu :slack:`#pyvec-members`.
+- Výbor se ideálně pokusí členy motivovat k tomu, aby kandidovali, a to komunikací s členy, ukazováním toho, jak výbor pracuje, jak vypadá běžná schůze výboru (např. zveřejněním video nahrávky), apod. Výbor může také neformálně oslovovat vhodné kandidáty a přesvědčovat je, že mají kandidovat.
+- Kterýkoliv člen může někoho nominovat a tím jej motivovat ke kandidatuře, ale s kandidaturou musí nakonec dotyčný souhlasit, aby byla platná. Pro inspiraci, `kandidatury do EuroPython Society <https://www.europython-society.org/list-of-eps-board-candidates-for-20192020/>`__.
+- Konec podávání kandidatur je v den začátku voleb, tedy v den členské schůze. Technicky by možná šlo brát nové kandidáty i v průběhu voleb, ale vždy jsme si vystačili s přímočarým systémem, kdy se kandidáti podávají předem a pak už se jenom volí.
+
+Těsně před volbami
+------------------
+
+- Je důležité nezapomenout, že ne každý používá nebo pravidelně čte Slack. Mnoho členů Pyvce preferuje e-mail. Je proto dobré ještě před startem voleb poslat ještě jeden e-mail všem členům, kde se shrne, kdo (zatím) kandiduje a ideálně i s nějakým popisem, co by chtěl dělat.
+- Ať už z lásky, nebo kvůli usnášeníschopnosti, není špatný nápad napsat co nejvíce členům upomínku, že jsou volby, i pomocí SMS nebo různých messengerů.
 
 Začátek voleb
 -------------
 
-- V datum schůze se udělá vykopávací meeting, koordinace probíhá přes :slack:`#pyvec-members`.
-- Výbor členy obeznámí s technickým zázemím volby.
-- Členové následně dostávají týden na to, aby asynchronně volili.
-
-.. note::
-    Jaké máme technické zázemí volby? Petr Viktorin zmiňoval, že PSF používá `Helios Voting <https://vote.heliosvoting.org/>`__. Dořešit.
+- V datum schůze proběhne samotná členská schůze, kde se schválí účetní závěrka a kde má předseda či předsedkyně tradičně nějakou `State of the Union <https://en.wikipedia.org/wiki/State_of_the_Union>`_ promluvu.
+- Někdo z výboru (to je důležité) se ujme naklikání nového hlasování v `Helios Voting <https://vote.heliosvoting.org/>`_.
+- Výbor členy obeznámí s technickým zázemím volby a připomene, jak to celé funguje.
+- Následně se spustí hlasování a členové dostávají týden na to, aby asynchronně volili.
 
 Mechanika voleb
 ---------------
@@ -45,7 +50,7 @@ Mechanika voleb
 - Každý člen Pyvce má 5 hlasů (ve výboru je 5 lidí).
 - Po týdnu voleb se uzavře hlasování a starý výbor vyhodnotí hlasy.
 - Bere se prvních pět, kteří dostanou nejvíc hlasů.
-- Starý výbor vyhlásí výsledky přes :slack:`#pyvec-members`.
+- Starý výbor vyhlásí výsledky v e-mailu všem členům Pyvce a ideálně i přes :slack:`#pyvec-members`.
 
 Volby při remíze
 ----------------
@@ -59,14 +64,15 @@ Předání moci
 
 - Starý výbor zodpovídá za Pyvec až do předání moci.
 - Starý a nový výbor si naplánují meeting, kde se seznámí a dojde k ceremoniálu předání moci, k předání přístupů, zodpovězení různých otázek, atd.
-- Nový výbor si mezi sebou musí zvolit předsedu a může zvolit :term:`pokladníka <Pokladník>`.
-- Každý člen výboru má jeden hlas a funkci dostává ten, kdo má nejvíc hlasů.
-- Nový výbor dostává první závažný úkol, při kterém jej ideálně stínuje starý výbor a pomáhá mu k jeho dokončení: Kontaktovat právničky spolku, `AK Šichová <https://aksichova.cz/>`__, aby připravily papíry, kodifikovaly výsledek voleb a změnu zanesly do státního rejstříku (úkol není hotov, dokud na justice.cz nejsou u Pyvce vidět nová jména).
+- Nový výbor si mezi sebou musí zvolit předsedu a může zvolit :term:`pokladníka <Pokladník>`. Každý člen výboru má jeden hlas a funkci dostává ten, kdo má nejvíc hlasů.
+- Nový výbor dostává první závažný úkol, při kterém jej ideálně stínuje starý výbor a pomáhá mu k jeho dokončení: Kontaktovat právničku spolku, `AK Šichová <https://aksichova.cz/>`__, aby připravila papíry, kodifikovala výsledek voleb a změnu zanesla do státního rejstříku (úkol není hotov, dokud na justice.cz nejsou u Pyvce vidět nová jména).
 - Nový výbor oznámí své zvolení v :slack:`#announcements`.
 - Starý výbor zajistí vyhotovení zápisů ze zasedání členské schůze a z předání moci:
-    - Vyhotoví :ref:`zápisy do této dokumentace <zapisy>`,
-    - aktualizuje `soubor boards.toml <https://github.com/pyvec/docs.pyvec.org/blob/master/src/pyvec_docs/boards.toml>`_,
-    - aktualizuje role členů v `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__, čímž by se měl aktualizovat i web Pyvce
+
+  - Vyhotoví :ref:`zápisy do této dokumentace <zapisy>`,
+  - aktualizuje `soubor boards.toml <https://github.com/pyvec/docs.pyvec.org/blob/master/src/pyvec_docs/boards.toml>`_,
+  - aktualizuje role členů v `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__, čímž by se měl aktualizovat i web Pyvce.
+
 - Starý výbor předá novému vše ze seznamu níže.
 
 Co předat
@@ -74,8 +80,18 @@ Co předat
 
 Tento seznam je potřeba průběžně aktualizovat a dokumentovat během toho, jak bude nový výbor narážet na místa, kam jim ještě chybí přístupy:
 
-- Přístupy k seznamu členů tak, aby do něj mohl jen nový výbor,
-- `Trello výboru <https://trello.com/b/6GjKGJfq/board>`__,
-- placení sídla Pyvce,
-- přístup k bankovnímu účtu Pyvce a PayPalu, zrušit bankovní kartu a případně vytvořit novou,
-- předání papírové dokumentace spolku (šanon).
+- `Trello výboru <https://trello.com/b/6GjKGJfq/board>`__. Nejdřív se musí lidi pozvat do Workspace, potom i do nástěnky. Na nic jiného už Trello nepoužíváme, takže tady lze starý výbor vyházet.
+- Přístup do datové schránky spolku. Ten by snad měl přijít automaticky po tom, co se nový výbor zapíše do rejstříku.
+- Přenastavit přístupy a skupiny ve `správci hesel <https://hesla.pyvec.org>`_.
+- Přístup k bankovnímu účtu Pyvce, PayPalu, Stripu, apod. Toto je zpravidla možné až když je nový výbor zapsán v rejstříku a je k tomu potřeba jít do banky.
+- Telefonní čísla na 2FA do Google účtu. Mít tam aspoň dva lidi s přístupem.
+- Telefonní číslo na 2FA do Benevity. Bohužel lze nastavit jen jedno a posílají to pouze přes SMS.
+- Přístupy k `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__ tak, aby do něj mohl jen nový výbor. Nevyhazovat *service account*, díky kterému se členové přes API vypisují na web Pyvce, ale jinak všechny ostatní ano. Jsou tam osobní údaje členů, takže kvůli GDPR tam smí jen výbor.
+- Přístup k celé složce *Spolek* na Google Drive. Z tama není nutné vyhazovat starý výbor, spíš jde o to, aby tam všichni z nového výboru mohli.
+- Aktualizovat `tým na GitHubu <https://github.com/orgs/pyvec/teams/board>`_. Minimálně předseda by měl mít ownera na GitHubu k organizaci ``@pyvec``.
+- Placení sídla Pyvce.
+- Předání papírové dokumentace spolku (šanon). Už tam asi nic důležitého není a nové věci jsou už digitálně, ale co kdyby.
+- Přenastavení e-mailovů info@pyvec.org a board@pyvec.org. To *info* je externí e-mail pro všechny, kdo píšou Pyvci. Ten *board* se dřív používal jako interní e-mail výboru, ale dnes už se většinou používá Slack.
+- Nový výbor by si měl na Slacku vytvořit svůj privátní kanál, např. :slack:`#pyvec-board-2022-2025`. Každý výbor má svůj, v názvu má roky funkčního období.
+- Přenastavení skupiny ``@board`` na Slacku, aby označovala lidi z nového výboru. Minimálně předseda by měl mít ownera k celému Slacku.
+- Kdo chce, na Slacku si ve svém profilu může nastavit políčko *Pyvec Title* na *Board* nebo *Chair*. Kdo ze starého výboru tam měl *Board*, tak by si tam měl dát *Member*. Ale je otázka, jestli tohle vůbec někdo čte.

--- a/docs/operations/elections.rst
+++ b/docs/operations/elections.rst
@@ -12,8 +12,7 @@ Kdy se volí
 -----------
 
 - Předchozí volba: **8.4.2019**
-- Příští volba: **?.?.2022**, předpokládá se termín březen/duben
-- Příprava pro rok 2022 začíná: od 1. ledna
+- Příští volba: **21.3.2022**
 
 Příprava
 --------

--- a/docs/operations/elections.rst
+++ b/docs/operations/elections.rst
@@ -23,8 +23,12 @@ Příprava
 - Někdo z výboru vezme e-mailové adresy členů ze `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__ a pošle jim pozvánku na členskou schůzi. Pozvánka musí obsahovat místo, čas a program jednání členské schůze. Kromě toho by měl výbor schůzi oznámit i v kanálu :slack:`#pyvec-members`. (Pro inspiraci, pozvánka na členskou schůzi `EuroPython Society <https://www.europython-society.org/europython-society-general-assembly-2020/>`__.)
 - Výbor dá členům vědět, jak lze podávat nominace, jak kandidovat. Kandidovat do výboru může jakýkoliv člen Pyvce.
 - Ideálně se pokusí členy motivovat k tomu, aby kandidovali, a to komunikací s členy, ukazováním toho, jak výbor pracuje, jak vypadá běžná schůze výboru (např. zveřejněním video nahrávky), apod. Výbor může také neformálně oslovovat vhodné kandidáty a přesvědčovat je, že mají kandidovat.
+- Členové mohou někoho nominovat a tím jej motivovat ke kandidatuře, ale s kandidaturou musí nakonec dotyčný souhlasit, aby byla platná.
 - Přihlášky se oznamují v kanálu :slack:`#pyvec-members`. (Pro inspiraci, `kandidatury do EuroPython Society <https://www.europython-society.org/list-of-eps-board-candidates-for-20192020/>`__.) Seznam kandidátů by bylo dobré zapisovat třeba sem do této stránky, ať je někde přehledný seznam. Pozor na GDPR, kontrolovat v `seznamu členů <https://docs.google.com/spreadsheets/d/1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I/edit#gid=0>`__, zda daná osoba může být někde veřejně takto prezentovaná.
 - Neomezujeme kandidáty na ty přihlášené předem. Kandidáti se mohou navrhnout nebo nominovat jiné kandidáty klidně až v průběhu hlasování. Je ale pro hlasující lepší, když se mohou s kandidáty seznámit předem.
+
+.. note::
+    Dořešit, zda se opravdu mohou kandidáti přidávat nebo ubírat v průběhu voleb. Závisí na zvoleném technickém řešení, zda umožňuje měnit hlas v průběhu týdne.
 
 Začátek voleb
 -------------

--- a/src/pyvec_docs/ext/board_dates.py
+++ b/src/pyvec_docs/ext/board_dates.py
@@ -1,0 +1,26 @@
+from datetime import timedelta
+from typing import Any
+
+from sphinx.application import Sphinx
+from sphinx.config import Config
+
+from pyvec_docs.board import BOARDS_MANDATE_LENGTH, load_boards
+
+
+def board_dates(app: Sphinx, config: Config):
+    board = load_boards()[0]
+
+    board_start = board.start_on
+    board_end = board_start + timedelta(days=BOARDS_MANDATE_LENGTH * 365)
+
+    existing_epilog = app.config.rst_epilog or ""
+    app.config.rst_epilog = (
+        f"{existing_epilog}\n\n"
+        f".. |board_start| replace:: {board_start:%-d.%-m.%Y}\n"
+        f".. |board_end| replace:: {board_end:%Y}\n"
+    )
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.connect("config-inited", board_dates)
+    return {"version": "1.0", "parallel_read_safe": True, "parallel_write_safe": True}


### PR DESCRIPTION
- [x] Datum voleb, 21.3.?
- [x] Přečíst ještě [PEP 8102](https://www.python.org/dev/peps/pep-8102/) a případně se inspirovat? Dořešit.
- [ ] Dořešit, zda se opravdu mohou kandidáti přidávat nebo ubírat v průběhu voleb. Závisí na zvoleném technickém řešení, zda umožňuje měnit hlas v průběhu týdne.
- [ ] Jaké máme technické zázemí volby? @encukou zmiňoval, že PSF používá [Helios Voting](https://vote.heliosvoting.org/). Dořešit.
- [ ] K odkazu na seznam členů přidat do závorky, že kvůli GDPR tam má přístup jen výbor: ...Odkaz byl v https://docs.pyvec.org/operations/elections.html (odkazovaný z pondělní události) a je tam napsáno „Někdo z výboru vezme e-mailové adresy členů …”
- [x] předání moci: vytvořit nový private kanál na slacku s boardem
- [x] předání moci: na githubu změnit kdo je v board teamu (používá se to v codeowners atd.)
- [ ] telefonní čísla 2FA do Google účtu, mít tam aspoň dva lidi s přístupem
- [x] přístup do mailových grup info@ a board@
- [ ] přístup do bankovního účtu
- [ ] google drive owners?
- [x] mention board na slacku
- [ ] políčko pro funkci v pyvci na slacku na osobním profilu
- [x] předseda minimálně by měl mít ownera na githubu k organizaci a ke slacku
- [ ] benevity protože tam je telefon
- [ ] hesla.pyvec.org
- [ ] při sdílení trella je potřeba nasdílet nejdřív lidi do workspacu a potom do nástěnky board
- [ ] do hesel dát fakturoid a mailchimp