### PR TITLE
Change user agent and adjust concurrency settings

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -5,10 +5,14 @@ cache = true
 max_cache_age = "10m"
 
 # Stealth
-user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0"
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0"
+header = { "Accept" = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8", "Accept-Language" = "en-US,en;q=0.5", "Accept-Encoding" = "gzip, deflate, br" }
 
 # Prevent 'Too Many Open Files'
-max_concurrency = 32
+max_concurrency = 16
+
+# Slower retries give rate-limited servers time to cool down
+retry_wait_time = 5
 
 # Check links inside `<code>` and `<pre>` blocks and Markdown code blocks
 include_verbatim = true


### PR DESCRIPTION
Updated user agent string and modified concurrency settings. This should help with avoiding timeouts etc. when link checking. It helped me at junior.guru: https://github.com/juniorguru/junior.guru/blob/main/lychee.toml

The biggest difference is that at junior.guru I also added 403 as a valid response, because many blocks end up with 403, but I don't do it here now as I'm not sure docs.pyvec.org needs it. But when I did that at my project, I could remove most of the manually maintained exceptions completely. It, of course, could result in some links becoming genuinely broken, but IMHO it's a reasonable tax to pay. If links get broken, most often they become 500, 410, 404, etc.